### PR TITLE
Add sample YAML config and configurable retry count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # any2pg
-SQL Translator for any DB to PostgreSQL
+
+SQL Translator for any DB to PostgreSQL.
+
+## Usage
+
+This project provides a multi-agent pipeline powered by [autogen](https://github.com/microsoft/autogen)
+and [Ollama](https://ollama.ai) with the `gpt-oss:20b` model to translate SQL files into PostgreSQL
+compatible queries.
+
+```bash
+python main.py path/to/sql_dir path/to/output_dir --config config.yaml
+```
+
+Create a YAML configuration file to control execution, meta-pattern handling, and retry behaviour.
+
+```yaml
+max_rounds: 3
+execute:
+  enabled: true
+  dsn: postgresql://user:pass@host/db
+meta:
+  enabled: true
+  path: meta.json
+```
+
+A sample configuration file is available as `config.sample.yaml`.
+
+The script will recursively search for `*.sql` files in the input directory, translate each file, and
+write the PostgreSQL version to the output directory. When `execute.enabled` is true the converted
+query is executed against PostgreSQL and the result or error is printed. When `meta.enabled` is true
+general SQL patterns are stored in `meta.path` to improve future translations.
+
+Stored patterns are kept in a JSON file and automatically deduplicated:
+
+```json
+{
+  "patterns": [
+    {
+      "id": "e13a5c2f",
+      "source_pattern": "SELECT ${expr1} || ${expr2}",
+      "postgres_pattern": "SELECT ${expr1} || ${expr2}"
+    }
+  ]
+}
+```

--- a/any2pg/__init__.py
+++ b/any2pg/__init__.py
@@ -1,0 +1,5 @@
+"""any2pg package."""
+
+from .converter import convert_directory
+
+__all__ = ["convert_directory"]

--- a/any2pg/agents.py
+++ b/any2pg/agents.py
@@ -1,0 +1,200 @@
+"""Agent definitions for SQL translation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import json
+import psycopg
+from autogen import AssistantAgent
+
+
+@dataclass
+class BaseAgent:
+    """Base wrapper around :class:`autogen.AssistantAgent`."""
+
+    name: str
+    system_message: str
+    llm_config: dict
+    agent: AssistantAgent = field(init=False)
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple initialization
+        self.agent = AssistantAgent(
+            name=self.name, llm_config=self.llm_config, system_message=self.system_message
+        )
+
+    def run(self, prompt: str) -> str:
+        """Generate a response from the underlying LLM."""
+        return self.agent.generate_response(prompt)
+
+
+class SemanticAnalysisAgent(BaseAgent):
+    def analyze(self, sql: str) -> str:
+        prompt = f"""Analyze the semantics of the following SQL and describe any dialect specifics:
+
+{sql}
+"""
+        return self.run(prompt)
+
+
+class QueryWritingAgent(BaseAgent):
+    def write_postgres(
+        self, sql: str, analysis: str, patterns: list[dict[str, str]] | None = None
+    ) -> str:
+        pattern_txt = "\n\n".join(
+            f"Source Pattern:\n{p['source_pattern']}\nPostgres Pattern:\n{p['postgres_pattern']}"
+            for p in patterns or []
+        )
+        prompt = f"""Using the analysis below, rewrite the SQL so that it runs on PostgreSQL.
+
+Analysis:
+{analysis}
+
+Original SQL:
+{sql}
+
+Known Patterns:
+{pattern_txt}
+"""
+        return self.run(prompt)
+
+
+class ValidationAgent(BaseAgent):
+    def validate(self, postgres_sql: str) -> dict:
+        prompt = f"""Check whether the following SQL is valid PostgreSQL syntax. Return a JSON object with keys
+"approved" (true if the SQL is high quality), "sql" (the corrected SQL), and optional "reason" when not approved.
+
+{postgres_sql}
+"""
+        try:
+            return json.loads(self.run(prompt))
+        except Exception:  # pragma: no cover - model deviations
+            return {"approved": False, "sql": postgres_sql, "reason": "invalid response"}
+
+
+class KnowledgeAgent(BaseAgent):
+    """Agent responsible for internalizing knowledge from conversions."""
+
+    def internalize(self, analysis: str, result: str) -> str:
+        prompt = f"""Summarize the key learnings from the analysis and result to aid future translations.
+
+Analysis:
+{analysis}
+
+Result:
+{result}
+"""
+        return self.run(prompt)
+
+
+class MetaInfoAgent(BaseAgent):
+    """Agent that extracts and stores generalized SQL patterns."""
+
+    def __init__(
+        self,
+        name: str,
+        system_message: str,
+        llm_config: dict,
+        path: Optional[Path] = None,
+        enabled: bool = False,
+    ) -> None:
+        super().__init__(name=name, system_message=system_message, llm_config=llm_config)
+        self.path = Path(path) if path else None
+        self.enabled = enabled
+
+    def load_patterns(self) -> list[dict[str, str]]:
+        if not (self.enabled and self.path and self.path.exists()):
+            return []
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        patterns = data.get("patterns", []) if isinstance(data, dict) else data
+
+        unique: list[dict[str, str]] = []
+        seen = set()
+        for p in patterns:
+            key = (p.get("source_pattern"), p.get("postgres_pattern"))
+            if key not in seen:
+                seen.add(key)
+                unique.append(p)
+
+        if len(unique) != len(patterns):
+            self.path.write_text(
+                json.dumps({"patterns": unique}, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+        return unique
+
+    def save_pattern(self, source_sql: str, postgres_sql: str) -> None:
+        if not (self.enabled and self.path):
+            return
+
+        data = {"patterns": []}
+        if self.path.exists():
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        patterns: list[dict[str, str]] = data.setdefault("patterns", [])
+
+        source_pattern = self.run(
+            "Generalize the SQL into a pattern using placeholders for identifiers and literals. "
+            "Do not include schema or table names.\n\nSQL:\n" + source_sql
+        )
+        postgres_pattern = self.run(
+            "Generalize the SQL into a pattern using placeholders for identifiers and literals. "
+            "Do not include schema or table names.\n\nSQL:\n" + postgres_sql
+        )
+
+        import hashlib
+
+        pid = hashlib.sha256(
+            (source_pattern + "->" + postgres_pattern).encode("utf-8")
+        ).hexdigest()[:8]
+
+        for p in patterns:
+            if (
+                p.get("source_pattern") == source_pattern
+                and p.get("postgres_pattern") == postgres_pattern
+            ):
+                return
+
+        patterns.append(
+            {
+                "id": pid,
+                "source_pattern": source_pattern,
+                "postgres_pattern": postgres_pattern,
+            }
+        )
+        self.path.write_text(
+            json.dumps({"patterns": patterns}, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+
+class ExecutionAgent(BaseAgent):
+    """Agent that executes queries against PostgreSQL for verification."""
+
+    def __init__(
+        self,
+        name: str,
+        system_message: str,
+        llm_config: dict,
+        dsn: Optional[str] = None,
+        enabled: bool = False,
+    ) -> None:
+        super().__init__(name=name, system_message=system_message, llm_config=llm_config)
+        self.dsn = dsn
+        self.enabled = enabled
+
+    def execute(self, postgres_sql: str) -> str:
+        """Execute ``postgres_sql`` against the configured PostgreSQL database."""
+
+        if not (self.enabled and self.dsn):
+            return "Execution disabled"
+
+        try:
+            with psycopg.connect(self.dsn) as conn, conn.cursor() as cur:
+                cur.execute(postgres_sql)
+                if cur.description:
+                    rows = cur.fetchall()
+                    return f"Returned {len(rows)} rows"
+                return f"{cur.rowcount} rows affected"
+        except Exception as exc:  # pragma: no cover - connection errors
+            return f"Execution error: {exc}"

--- a/any2pg/converter.py
+++ b/any2pg/converter.py
@@ -1,0 +1,106 @@
+"""Directory-based SQL conversion pipeline."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from .agents import (
+    ExecutionAgent,
+    KnowledgeAgent,
+    MetaInfoAgent,
+    QueryWritingAgent,
+    SemanticAnalysisAgent,
+    ValidationAgent,
+)
+
+def convert_sql(
+    sql: str,
+    *,
+    semantic: SemanticAnalysisAgent,
+    writer: QueryWritingAgent,
+    validator: ValidationAgent,
+    knowledge: KnowledgeAgent,
+    executor: ExecutionAgent,
+    meta: MetaInfoAgent,
+    max_rounds: int = 3,
+) -> str:
+    """Convert a single SQL string into PostgreSQL SQL using the agent pipeline.
+
+    A simple feedback loop retries validation/execution errors up to ``max_rounds`` times.
+    """
+
+    patterns = meta.load_patterns()
+    current = sql
+    original = sql
+    for _ in range(max_rounds):
+        analysis = semantic.analyze(current)
+        postgres_sql = writer.write_postgres(current, analysis, patterns)
+        validation = validator.validate(postgres_sql)
+        if not validation.get("approved", False):
+            current = validation.get("sql", postgres_sql)
+            continue
+        candidate = validation["sql"]
+        exec_result = executor.execute(candidate)
+        if executor.enabled and exec_result.lower().startswith("execution error"):
+            current = candidate  # feedback loop with error info
+            continue
+        meta.save_pattern(original, candidate)
+        knowledge.internalize(analysis, candidate)
+        print(exec_result)
+        return candidate
+    raise RuntimeError("conversion failed")
+
+
+def iter_sql_files(input_dir: Path) -> Iterable[Path]:
+    """Yield all ``.sql`` files under ``input_dir``."""
+    yield from input_dir.rglob("*.sql")
+
+
+def convert_directory(input_dir: str, output_dir: str, llm_config: dict, config: dict) -> None:
+    """Convert all SQL files in ``input_dir`` and write PostgreSQL versions to ``output_dir``."""
+    in_path = Path(input_dir)
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    exec_cfg = config.get("execute", {})
+    meta_cfg = config.get("meta", {})
+    max_rounds = config.get("max_rounds", 3)
+
+    semantic = SemanticAnalysisAgent("semantic", "You analyze SQL semantics.", llm_config)
+    writer = QueryWritingAgent("writer", "You translate SQL to PostgreSQL.", llm_config)
+    validator = ValidationAgent("validator", "You validate PostgreSQL syntax.", llm_config)
+    knowledge = KnowledgeAgent("knowledge", "You store conversion knowledge.", llm_config)
+    executor = ExecutionAgent(
+        "executor",
+        "You verify execution results.",
+        llm_config,
+        dsn=exec_cfg.get("dsn"),
+        enabled=exec_cfg.get("enabled", False),
+    )
+    meta = MetaInfoAgent(
+        "meta",
+        "You manage reusable SQL patterns.",
+        llm_config,
+        path=meta_cfg.get("path"),
+        enabled=meta_cfg.get("enabled", False),
+    )
+
+    for sql_file in iter_sql_files(in_path):
+        relative = sql_file.relative_to(in_path)
+        target = out_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        print(f"Converting {sql_file} -> {target}")
+
+        sql_text = sql_file.read_text(encoding="utf-8")
+        converted = convert_sql(
+            sql_text,
+            semantic=semantic,
+            writer=writer,
+            validator=validator,
+            knowledge=knowledge,
+            executor=executor,
+            meta=meta,
+            max_rounds=max_rounds,
+        )
+        target.write_text(converted, encoding="utf-8")
+        print(f"Written {target}")

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,0 +1,11 @@
+# Sample configuration for any2pg
+# Number of attempts to resolve validation or execution errors
+max_rounds: 3
+
+execute:
+  enabled: false
+  dsn: postgresql://user:pass@host/db
+
+meta:
+  enabled: false
+  path: meta.json

--- a/main.py
+++ b/main.py
@@ -1,0 +1,48 @@
+"""Command line interface for any2pg."""
+from __future__ import annotations
+
+import argparse
+
+import yaml
+
+from any2pg import convert_directory
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Translate SQL files to PostgreSQL.")
+    parser.add_argument("input", help="Input directory containing SQL files")
+    parser.add_argument("output", help="Output directory for PostgreSQL SQL files")
+    parser.add_argument(
+        "--model",
+        default="gpt-oss:20b",
+        help="Ollama model to use (default: gpt-oss:20b)",
+    )
+    parser.add_argument(
+        "--ollama-base-url",
+        default="http://localhost:11434",
+        help="Base URL for the Ollama server",
+    )
+    parser.add_argument(
+        "--config",
+        help="YAML configuration file for execution and meta options",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    llm_config = {
+        "model": args.model,
+        "api_type": "ollama",
+        "base_url": args.ollama_base_url,
+    }
+    config = {}
+    if args.config:
+        with open(args.config, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f) or {}
+    convert_directory(args.input, args.output, llm_config, config)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+autogen
+psycopg[binary]
+pyyaml


### PR DESCRIPTION
## Summary
- allow retry limit to be configured via `max_rounds` in YAML
- document and provide a sample `config.sample.yaml`

## Testing
- `python -m py_compile any2pg/__init__.py any2pg/agents.py any2pg/converter.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b82a3c9268832fbf498494409ef539