### PR TITLE
Use generate_reply in BaseAgent run method

### DIFF
--- a/any2pg/agents.py
+++ b/any2pg/agents.py
@@ -26,7 +26,10 @@ class BaseAgent:
 
     def run(self, prompt: str) -> str:
         """Generate a response from the underlying LLM."""
-        return self.agent.generate_response(prompt)
+        reply = self.agent.generate_reply(messages=[{"role": "user", "content": prompt}])
+        if isinstance(reply, dict):
+            return reply.get("content", "")
+        return str(reply)
 
 
 class SemanticAnalysisAgent(BaseAgent):


### PR DESCRIPTION
## Summary
- Replace `generate_response` with `generate_reply` in `BaseAgent.run`
- Handle dictionary replies by returning their `content`

## Testing
- `python -m py_compile any2pg/agents.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8dda58c38832fa6eff13f98ef394c